### PR TITLE
reproduce weird warning in td24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,19 @@
       "resolved": "packages/foo",
       "link": true
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/ansi-sequence-parser": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
@@ -44,6 +57,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lunr": {
       "version": "2.3.9",
@@ -136,7 +154,9 @@
       "name": "@typedoc/foo",
       "version": "0.0.2",
       "dependencies": {
-        "@typedoc/bar": "0.0.1"
+        "@typedoc/bar": "0.0.1",
+        "@types/lodash-es": "4.17.7",
+        "lodash-es": "4.17.21"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
     ],
     "name": "Packages Example",
     "entryPointStrategy": "packages",
+    "exclude": [
+      "**/node_modules/**",
+      "**/packages/**/node_modules/**"
+    ],
+    "externalPattern": [
+      "**/node_modules/**"
+    ],
+    "excludeExternals": true,
     "includeVersion": true
   }
 }

--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -3,8 +3,11 @@
   "version": "0.0.2",
   "exports": "./dist/index.js",
   "dependencies": {
-    "@typedoc/bar": "0.0.1"
+    "@types/lodash-es": "4.17.7",
+    "@typedoc/bar": "0.0.1",
+    "lodash-es": "4.17.21"
   },
+  "type": "module",
   "typedocOptions": {
     "entryPoints": [
       "src/index.ts"

--- a/packages/foo/src/index.ts
+++ b/packages/foo/src/index.ts
@@ -4,6 +4,21 @@
  */
 
 import { bar } from "@typedoc/bar";
+import {
+  cloneDeep as deepClone,
+  isEqual as deepEqual,
+  findLast,
+  isEmpty,
+  pickBy,
+  uniqBy,
+  uniq,
+  debounce,
+  throttle,
+  mergeWith,
+  toNumber,
+  type DebouncedFunc,
+  isObject,
+} from "lodash-es";
 
 /**
  * Docs for `foo` function, which returns a {@link @typedoc/bar!BarInt}
@@ -11,3 +26,18 @@ import { bar } from "@typedoc/bar";
 export function foo() {
   return bar();
 }
+
+// NOTE: We re-export lodash utilities like this so we centralize utility usage in our app
+// in case we want to swap out the implementation
+export {
+  deepClone,
+  deepEqual,
+  findLast,
+  isEmpty,
+  pickBy,
+  uniqBy,
+  uniq,
+  debounce,
+  throttle,
+  type DebouncedFunc,
+};


### PR DESCRIPTION
```sh
npm run build
npm run docs
```

I have made sure to exclude files coming from `node_modules` with

```jsonc
// package.json
  ...
  "typedocOptions": {
    "entryPoints": [
      "."
    ],
    "name": "Packages Example",
    "entryPointStrategy": "packages",
    "exclude": [
      "**/node_modules/**",
      "**/packages/**/node_modules/**"
    ],
    "externalPattern": [
      "**/node_modules/**"
    ],
    "excludeExternals": true,
    "includeVersion": true
  }
```

warnings that I see

```
❯ npm run docs

> docs
> typedoc

[info] Converting project at ./packages/foo
./node_modules/@types/lodash/common/array.d.ts:1720:21 - [warning] Encountered an unescaped open brace without an inline tag

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1720:30 - [warning] Unmatched closing brace

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1720:33 - [warning] Encountered an unescaped open brace without an inline tag

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1720:42 - [warning] Unmatched closing brace

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1720:45 - [warning] Encountered an unescaped open brace without an inline tag

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1720:54 - [warning] Unmatched closing brace

1720             * _.uniqBy([{ 'x': 1 }, { 'x': 2 }, { 'x': 1 }], 'x');

./node_modules/@types/lodash/common/array.d.ts:1721:18 - [warning] Encountered an unescaped open brace without an inline tag

1721             * // => [{ 'x': 1 }, { 'x': 2 }]

./node_modules/@types/lodash/common/array.d.ts:1721:27 - [warning] Unmatched closing brace

1721             * // => [{ 'x': 1 }, { 'x': 2 }]

./node_modules/@types/lodash/common/array.d.ts:1721:30 - [warning] Encountered an unescaped open brace without an inline tag

1721             * // => [{ 'x': 1 }, { 'x': 2 }]

./node_modules/@types/lodash/common/array.d.ts:1721:39 - [warning] Unmatched closing brace

1721             * // => [{ 'x': 1 }, { 'x': 2 }]

[info] Converting project at ./packages/bar
[info] Merging converted projects
[info] Documentation generated at ./docs
```