### PR TITLE
resolution bug in 0.24.x when `exclude` flags cause references to not be resolved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
       "name": "typedoc-packages-example",
       "workspaces": [
         "packages/foo",
-        "packages/bar"
+        "packages/bar",
+        "packages/test"
       ],
       "dependencies": {
-        "typedoc": "^0.24.0",
+        "typedoc": "0.24.1",
         "typescript": "^4.9.5"
       }
     },
@@ -75,6 +76,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mobx": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.9.0.tgz",
+      "integrity": "sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
+    "node_modules/serializr": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/serializr/-/serializr-3.0.2.tgz",
+      "integrity": "sha512-bCACTuCiAEjtk1NxkATc3yz2j/8OoaWYxRkC4D5yq0ikZeLO7KLmmI/owmvJ/N4vS9SX4fZTXgSmsNzWtxDJ/Q=="
+    },
     "node_modules/shiki": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
@@ -86,10 +101,14 @@
         "vscode-textmate": "^8.0.0"
       }
     },
+    "node_modules/test": {
+      "resolved": "packages/test",
+      "link": true
+    },
     "node_modules/typedoc": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.0.tgz",
-      "integrity": "sha512-yNbhPdDCb67r+v+SRcyXDp5JTImMqHHOFQDI7zciT7rXJnJt5UD9wz1Z4WllCVm5Ey92j2bOML0hnaiK1Pk2JA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.1.tgz",
+      "integrity": "sha512-u4HwjZcSQhQSkkhLjgcs0ooAf6HrFVLDHHrwU2xZW8WxH0KnGZlNkaWxiOcK5Gagj7mxJSgwWx0dv8ACDAOXAQ==",
       "dependencies": {
         "lunr": "^2.3.9",
         "marked": "^4.2.12",
@@ -137,6 +156,22 @@
       "version": "0.0.2",
       "dependencies": {
         "@typedoc/bar": "0.0.1"
+      }
+    },
+    "packages/legend-shared": {
+      "extraneous": true,
+      "dependencies": {
+        "mobx": "6.9.0",
+        "serializr": "3.0.2"
+      },
+      "devDependencies": {
+        "typescript": "5.0.4"
+      }
+    },
+    "packages/test": {
+      "dependencies": {
+        "mobx": "6.9.0",
+        "serializr": "3.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "private": true,
   "workspaces": [
     "packages/foo",
-    "packages/bar"
+    "packages/bar",
+    "packages/test"
   ],
   "scripts": {
     "build": "tsc --build",
     "docs": "typedoc"
   },
   "dependencies": {
-    "typedoc": "^0.24.0",
+    "typedoc": "0.24.1",
     "typescript": "^4.9.5"
   }
 }

--- a/packages/bar/src/index.ts
+++ b/packages/bar/src/index.ts
@@ -7,10 +7,13 @@
  * Docs for `bar` function.
  */
 export function bar(): BarInt {
-    console.log("Bar");
-    return { bar: true };
+  console.log("Bar");
+  return { bar: true };
 }
 
+/**
+ * BarInt interface
+ */
 export interface BarInt {
-    bar: true;
+  bar: true;
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test",
+  "sideEffects": false,
+  "type": "module",
+  "dependencies": {
+    "mobx": "6.9.0",
+    "serializr": "3.0.2"
+  }
+}

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,0 +1,24 @@
+import { SKIP } from "serializr";
+
+/**
+ * asd
+ */
+type Skipped = typeof SKIP;
+
+export const deserializeArray = (): Skipped => {
+  throw new Error("");
+};
+
+export const serializeArray = (): Skipped => {
+  throw new Error("");
+};
+
+export class ActionState {
+  private _messageFormatter: ((message: string) => string) | undefined;
+
+  setMessageFormatter(val: ((message: string) => string) | undefined): void {}
+}
+
+export class SomeType {
+  response!: string & { data?: object };
+}

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/test/typedoc.json
+++ b/packages/test/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "./packages/foo"
+    },
+    {
+      "path": "./packages/test"
     }
   ]
 }

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,4 +1,25 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "includeVersion": true
+  "includeVersion": true,
+  "intentionallyNotExported": [],
+  "validation": {
+    "notExported": false,
+    "invalidLink": true,
+    "notDocumented": false
+  },
+  "visibilityFilters": {
+    "protected": false,
+    "private": false,
+    "inherited": true,
+    "external": false,
+    "@internal": false
+  },
+  "externalPattern": [
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/node_modules/**"
+  ],
+  "excludeExternals": true,
+  "excludeInternal": true,
+  "excludeNotDocumented": true
 }


### PR DESCRIPTION
```sh
npm run build
npm run docs
```

I enabled `excludeNotDocumented` in the base typedoc config and I found several warnings/errors that's hard to reason out

```
❯ npm run docs

> docs
> typedoc

[info] Converting project at ./packages/foo
[info] Converting project at ./packages/bar
[info] Converting project at ./packages/test
[info] Merging converted projects
[warning] Serialized project contained a reflection with id node_modules/serializr/lib/constants.d.ts __type 3 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id node_modules/serializr/lib/constants.d.ts __type 6 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type 11 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type 12 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts message 13 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type 17 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type 18 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts message 19 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type 24 but it was not present in deserialized project.
[warning] Serialized project contained a reflection with id packages/test/src/index.ts __type.data 25 but it was not present in deserialized project.
[info] Documentation generated at ./docs```